### PR TITLE
return write error from sendAsNetstring

### DIFF
--- a/kamevapi.go
+++ b/kamevapi.go
@@ -124,14 +124,11 @@ func (kea *KamEvapi) readEvents(exitChan chan struct{}, errReadEvents chan error
 	}
 }
 
-// Formats string content as netstring and sends over the socket
-func (kea *KamEvapi) sendAsNetstring(dataStr string) error {
-	cntLen := len([]byte(dataStr)) // Netstrings require number of bytes sent
-	dataOut := fmt.Sprintf("%d:%s,", cntLen, dataStr)
+func (kea *KamEvapi) sendAsNetstring(s string) error {
 	kea.connMutex.RLock()
-	fmt.Fprint(kea.conn, dataOut)
-	kea.connMutex.RUnlock()
-	return nil
+	defer kea.connMutex.RUnlock()
+	_, err := fmt.Fprintf(kea.conn, "%d:%s,", len(s), s)
+	return err
 }
 
 // Dispatch the event received from Kamailio towards handlers matching it

--- a/kamevapi_test.go
+++ b/kamevapi_test.go
@@ -398,6 +398,18 @@ func TestSendAsNetstring(t *testing.T) {
 	}
 }
 
+func TestSendAsNetstringWriteError(t *testing.T) {
+	w, r := net.Pipe()
+	r.Close()
+	kea := &KamEvapi{
+		conn:      w,
+		connMutex: new(sync.RWMutex),
+	}
+	if err := kea.sendAsNetstring("test"); err != io.ErrClosedPipe {
+		t.Errorf("sendAsNetstring err = %v, want %v", err, io.ErrClosedPipe)
+	}
+}
+
 func TestReadNetstring(t *testing.T) {
 	kea := &KamEvapi{
 		rcvBuffer: bufio.NewReader(bytes.NewBufferString("7:string!,")),


### PR DESCRIPTION
fmt.Fprint's return was discarded so Send returned nil on broken sockets.